### PR TITLE
making some inputs optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_gateway_ip_address"></a> [gateway\_ip\_address](#input\_gateway\_ip\_address) | IP Address of the SGW appliance in vSphere | `string` | n/a | yes |
 | <a name="input_gateway_name"></a> [gateway\_name](#input\_gateway\_name) | Storage Gateway Name | `string` | n/a | yes |
-| <a name="input_organizational_unit"></a> [organizational\_unit](#input\_organizational\_unit) | The organizational unit (OU) is a container in an Active Directory that can hold users, groups, computers, and other OUs and this parameter specifies the OU that the gateway will join within the AD domain. | `string` | n/a | yes |
-| <a name="input_timeout_in_seconds"></a> [timeout\_in\_seconds](#input\_timeout\_in\_seconds) | Specifies the time in seconds, in which the JoinDomain operation must complete. The default is 20 seconds. | `number` | n/a | yes |
 | <a name="input_disk_path"></a> [disk\_path](#input\_disk\_path) | Path on the SGW appliance in vsphere where the cache disk resides on the OS | `string` | `"/dev/sdb"` | no |
 | <a name="input_domain_controllers"></a> [domain\_controllers](#input\_domain\_controllers) | List of IPv4 addresses, NetBIOS names, or host names of your domain server. If you need to specify the port number include it after the colon (“:”). For example, mydc.mydomain.com:389. | `list(any)` | `[]` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The name of the domain that you want the gateway to join | `string` | `""` | no |
@@ -172,6 +170,8 @@ No modules.
 | <a name="input_domain_username"></a> [domain\_username](#input\_domain\_username) | The user name for the service account on your self-managed AD domain that SGW use to join to your AD domain | `string` | `""` | no |
 | <a name="input_gateway_type"></a> [gateway\_type](#input\_gateway\_type) | Type of the gateway. Valid options are FILE\_S3, FILE\_FSX\_SMB, VTL, CACHED, STORED | `string` | `"FILE_S3"` | no |
 | <a name="input_join_smb_domain"></a> [join\_smb\_domain](#input\_join\_smb\_domain) | Setting for controlling whether to join the Storage gateway to an Active Directory (AD) domain for Server Message Block (SMB) file shares. Variables domain\_controllers, domain\_name, password and username should also be specified to join AD domain. | `bool` | `false` | no |
+| <a name="input_organizational_unit"></a> [organizational\_unit](#input\_organizational\_unit) | The organizational unit (OU) is a container in an Active Directory that can hold users, groups, computers, and other OUs and this parameter specifies the OU that the gateway will join within the AD domain. | `string` | `""` | no |
+| <a name="input_timeout_in_seconds"></a> [timeout\_in\_seconds](#input\_timeout\_in\_seconds) | Specifies the time in seconds, in which the JoinDomain operation must complete. The default is 20 seconds. | `number` | `-1` | no |
 | <a name="input_timezone"></a> [timezone](#input\_timezone) | Time zone for the gateway. The time zone is of the format GMT, GMT-hr:mm, or GMT+hr:mm.For example, GMT-4:00 indicates the time is 4 hours behind GMT. Avoid prefixing with 0 | `string` | `"GMT"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -19,13 +19,15 @@ resource "aws_storagegateway_gateway" "mysgw" {
 
     content {
 
-      domain_name        = var.domain_name
-      password           = var.domain_password
-      username           = var.domain_username
-      domain_controllers = var.domain_controllers
+      # Required inputs
+      domain_name = var.domain_name
+      password    = var.domain_password
+      username    = var.domain_username
 
-      timeout_in_seconds  = var.timeout_in_seconds
-      organizational_unit = var.organizational_unit
+      # Optional inputs
+      domain_controllers  = var.domain_controllers
+      timeout_in_seconds  = var.timeout_in_seconds >= 0 ? var.timeout_in_seconds : null
+      organizational_unit = len(var.organizational_unit) > 0 ? var.organizational_unit : null
 
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,12 +34,14 @@ variable "domain_password" {
 variable "timeout_in_seconds" {
   type        = number
   sensitive   = false
+  default     = -1
   description = "Specifies the time in seconds, in which the JoinDomain operation must complete. The default is 20 seconds."
 }
 
 variable "organizational_unit" {
   type        = string
   sensitive   = false
+  default     = ""
   description = "The organizational unit (OU) is a container in an Active Directory that can hold users, groups, computers, and other OUs and this parameter specifies the OU that the gateway will join within the AD domain."
 }
 


### PR DESCRIPTION
Updated so that user does not need to input `timeout_in_seconds`, `organizational_unit` or `domain_controllers`. 